### PR TITLE
:green_heart: #17 避免 [unspecified]

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,6 +26,8 @@ val platformDownloadSources: String by project
 val platformPlugins: String by project
 val pluginVerifierIdeVersions: String by project
 
+version = pluginVersion
+
 // Configure project's dependencies
 repositories {
     mavenCentral()


### PR DESCRIPTION
本地运行 patchChangelog 时，会生成[0.1.3]而不是[unspecified]。
是对比  cc47d7876499f45142817c79ca3c4ae541cfe89e 38b0d239f36682df48151e4a9383f0d7975f1e18 两个版本看出来的，但不明所以。。