### PR TITLE
:white_check_mark: #10 添加 Java、Kotlin 补全测试用例

### DIFF
--- a/src/test/kotlin/CompletionTests.kt
+++ b/src/test/kotlin/CompletionTests.kt
@@ -1,5 +1,6 @@
 import com.github.tuchg.nonasciicodecompletionhelper.utils.countContainsSomeChar
 import com.github.tuchg.nonasciicodecompletionhelper.utils.toPinyin
+import com.google.wireless.android.sdk.stats.IntellijProjectSizeStats
 import com.intellij.testFramework.fixtures.CompletionAutoPopupTestCase
 import pansong291.simplepinyin.Pinyin
 import kotlin.system.measureTimeMillis
@@ -21,6 +22,40 @@ class CompletionTests : CompletionAutoPopupTestCase() {
 
     fun `test @补全功能性测试`() {
         //myFixture.testCompletionVariants("", "han")
+    }
+
+    fun `test @Java英文命名补全无效`() {
+        myFixture.configureByText("Test.java", "class a { int method() { <caret> } }")
+        myFixture.type("me")
+        val 补全项 = myFixture.completeBasic()
+        Assert.assertNull("补全项应为空", 补全项)
+    }
+
+    fun `test @Java补全成功`() {
+        myFixture.configureByText("Test.java", "class a { int 方法() { <caret> } }")
+        myFixture.type("fang")
+        val 补全项 = myFixture.completeBasic()
+        Assert.assertTrue("补全项不应为空", 补全项.isNotEmpty())
+        Assert.assertEquals(2, 补全项.size)
+        Assert.assertEquals("方法", 补全项.get(0).lookupString)
+        Assert.assertEquals("方法", 补全项.get(1).lookupString)
+    }
+
+    fun `test @Java输入错误后无补全`() {
+        myFixture.configureByText("Test.java", "class a { int 方法() { <caret> } }")
+        myFixture.type("fo")
+        val 补全项 = myFixture.completeBasic()
+        Assert.assertTrue("补全项应为空", 补全项.isEmpty())
+    }
+
+    fun `test @Kotlin补全成功`() {
+        myFixture.configureByText("Test.kt", "class a { fun 方法(): Int { <caret> } }")
+        myFixture.type("fang")
+        val 补全项 = myFixture.completeBasic()
+        Assert.assertTrue("补全项不应为空", 补全项.isNotEmpty())
+        Assert.assertEquals(2, 补全项.size)
+        Assert.assertEquals("方法", 补全项.get(0).lookupString)
+        Assert.assertEquals("方法", 补全项.get(1).lookupString)
     }
 
     fun `test @补全核心正确性测试`() {


### PR DESCRIPTION
虽然没能重现 kotlin 问题，但至少说明插件本身对 kotlin 的补全效果与 java 相同。会不会是IDEA 自己的补全机制对 kotlin 有什么特别处理把插件效果给覆盖了？

还有不明白的是，为何补全项有两个？
另外，好奇这个 myFixture 是怎么绑定自定义的 CompletionContributor 的（也许有些默认规则？）

刚发现多引入一个多余的 import，要重提 pr 吗？还是下次删掉？

一些参考资料：
- https://github.com/JetBrains/intellij-community/blob/19306e6d29182ef0d906e7f60054e0de11861da0/plugins/sh/tests/com/intellij/sh/completion/ShKeywordCompletionTest.java
- https://www.plugin-dev.com/intellij/editor/postfix-template-provider/